### PR TITLE
Fix/computed paginate

### DIFF
--- a/dist/store/menu.js
+++ b/dist/store/menu.js
@@ -75,7 +75,6 @@ var createStore = function createStore(_ref) {
       this.pages = chunk(this.menuItems, maxItems);
       this.paginateSlot = this.pages[this.activePage];
       if (!this.paginateSlot) {
-        debugger;
       }
     },
     createPages: function createPages() {

--- a/src/App.js
+++ b/src/App.js
@@ -72,8 +72,26 @@ const SelectContainer = styled.div`
 `;
 
 class App extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      store: null
+    };
+  }
   addItem = () => {
-    selectOptions.menuItems.push({label: 'new item'});
+    //selectOptions.menuItems.push({label: 'new item'});
+    if (this.state.store) {
+      this.state.store.menuItems.push({label: 'new item'});
+    }
+  }
+  onSelect = (selected, id) => {
+    //debugger
+  }
+  onUpdate = (menuItems) => {
+    //debugger
+  }
+  getStore = (store) => {
+    this.setState({'store': store});
   }
 
   render () {
@@ -94,7 +112,13 @@ class App extends Component {
         </MenuLauncher>
         <h1>Select Menu</h1>
         <SelectContainer>
-          <Select {...selectOptions}>
+          <Select
+            {...selectOptions}
+            onSelect={this.onSelect}
+            onUpdate={this.onUpdate}
+            getStore={this.getStore}
+          
+          >
           </Select>
         </SelectContainer>
         <button onClick={this.addItem}>Add item into Select</button>

--- a/src/App.js
+++ b/src/App.js
@@ -78,10 +78,10 @@ class App extends Component {
       store: null
     };
   }
-  addItem = () => {
+  addItem() {
     //selectOptions.menuItems.push({label: 'new item'});
     if (this.state.store) {
-      this.state.store.menuItems.push({label: 'new item'});
+      this.state.store.addItem({label: 'new item'});
     }
   }
   onSelect = (selected, id) => {
@@ -93,7 +93,6 @@ class App extends Component {
   getStore = (store) => {
     this.setState({'store': store});
   }
-
   render () {
     let fa = "fa fa-heart";
     return (
@@ -121,7 +120,7 @@ class App extends Component {
           >
           </Select>
         </SelectContainer>
-        <button onClick={this.addItem}>Add item into Select</button>
+        <button onClick={this.addItem.bind(this)}>Add item into Select</button>
 
       </div>
     );

--- a/src/components/Menu/AddableMenuItem.js
+++ b/src/components/Menu/AddableMenuItem.js
@@ -55,7 +55,9 @@ const UnstagedDisplay = observer((props) => {
 })
 
 class AddableMenuItem extends Component {
-
+  handleClick(ev) {
+    //ev.stopPropagation();
+  }
   render () {
     return (
       <StyledMenuItem

--- a/src/components/Menu/Menu.js
+++ b/src/components/Menu/Menu.js
@@ -199,9 +199,11 @@ const Menu = observer(class Menu extends Component {
 
     let hovering = this.state.store.hovering; //get the currently selected item
     let item = this.state.store.menuItems.find(item => item.id === hovering); //get the selected item
+    
     if ((hovering !== null) && item && item.id > 0) { //do nothing if its the last item
       this.state.store.hovering = findPreviousNode(item.id)//item.id - 1;
       this.state.store.refocusPage();
+      
     }
   }
 
@@ -228,9 +230,9 @@ const Menu = observer(class Menu extends Component {
 
     let hovering = this.state.store.hovering; //get the currently selected item
     let item = this.state.store.menuItems.find(item => item.id === hovering); //get the selected item
+
     if ((hovering !== null) && item && item.id < (this.state.store.menuItems.length - 1)) { //do nothing if its the last item
       this.state.store.hovering = findNextNode(item.id); //item.id + 1;
-      
       this.state.store.refocusPage();
     }
   }
@@ -313,13 +315,17 @@ const Menu = observer(class Menu extends Component {
     //ReactDOM.findDOMNode(this.refs.box).focus();
   }
 
-  scrollUp(ev) {
+  scrollUp(ev, id) {
     ev.stopPropagation();
-    this.state.store.prevPage();
+    this.state.store.setHovering(id);
+    this.decrementCursor();
+
   }
-  scrollDown(ev) {
+  scrollDown(ev, id) {
     ev.stopPropagation();
-    this.state.store.nextPage();
+    //this.state.store.nextPage();
+    this.state.store.setHovering(id);
+    this.incrementCursor();
   }
   preventClose(ev) {
     ev.stopPropagation();
@@ -327,6 +333,7 @@ const Menu = observer(class Menu extends Component {
 
   render() {
     // [icon or check] [label or html or editable] [tips] [shortcuts] [expandable]
+    let paginateSlot = this.state.store.paginateSlot;
     return (
       <StyledMenuBox
         onMouseEnter={this.bindKeys.bind(this)}
@@ -343,7 +350,7 @@ const Menu = observer(class Menu extends Component {
         
         {((this.state.store.pages.length > 1) && (this.state.store.activePage > 0)) ? (
           <UpButton
-            onClick={this.scrollUp.bind(this)}
+            onClick={(ev) => { this.scrollUp(ev, paginateSlot[0].id) }}
           >
             <IconDisplay iconType="fa-backward" /> Previous...
           </UpButton>
@@ -374,7 +381,7 @@ const Menu = observer(class Menu extends Component {
         {((this.state.store.pages.length > 1) && (this.state.store.activePage < (this.state.store.pages.length - 1))) ? (
           <span>
             <DownButton
-              onClick={this.scrollDown.bind(this)}
+              onClick={(ev) => { this.scrollDown(ev, paginateSlot[paginateSlot.length - 1].id) }}
             >
               <IconDisplay iconType="fa-forward" /> More...
             </DownButton>

--- a/src/components/Menu/Menu.js
+++ b/src/components/Menu/Menu.js
@@ -77,6 +77,9 @@ const Menu = observer(class Menu extends Component {
         // menuItems: props.menuItems,
         //menuItems: props.menuItems,
       };
+
+      this.props.onInit(this.state.store);
+      
     }
     this.clearHover = this.clearHover.bind(this);
 
@@ -88,14 +91,27 @@ const Menu = observer(class Menu extends Component {
     //avoid any multiple bound functions for a single instance tomfoolery
     this.handlers.keydown = this.handleKeyDown.bind(this);
 
-    this.dispose = {};
-
+    autorun(() => {
+      let store = this.state.store;
+      props.onUpdate({
+        menuItems: store.menuItems
+      });
+    });
+    
+    autorun(() => {
+      let store = this.state.store;
+      
+      if (store.selected) {
+        props.onSelect(store.menuItems[store.selected], store.selected);
+      }
+    });
+    props.getStore(this.state.store);
   }
 
   componentWillMount() {
     //this.handlers.key = this.handlerKeyDown.bind(this);
-
     // focus on the first item
+    
   }
 
   componentDidMount() {
@@ -389,7 +405,10 @@ const Menu = observer(class Menu extends Component {
 
 Menu.propTypes = {
   focused: PropTypes.bool,
-
+  onInit: PropTypes.func,
+  onUpdate: PropTypes.func,
+  onSelect: PropTypes.func,
+  getStore: PropTypes.func,
   menuMeta: PropTypes.shape({
     store: PropTypes.object, //used if we are injecting a store
     positioning: PropTypes.object,
@@ -423,6 +442,10 @@ Menu.defaultProps = {
   position: 'relative',
   top: '0',
   left: '0',
+  onInit: (store) => {},
+  onUpdate: (store) => {},
+  getStore: (store) => {},
+  onSelect: () => {},
   select: {
   // align: 'left' / 'right' / 'left-wide'
   },

--- a/src/components/Menu/Menu.js
+++ b/src/components/Menu/Menu.js
@@ -272,7 +272,10 @@ const Menu = observer(class Menu extends Component {
       case 'Enter':
         //this.returnSelected();
         this.state.store.selectItem(this.state.store.hovering);
-        this.state.store.refocusPage();
+        if (this.props.positioning) {
+          this.props.positioning.closeMenu();
+        }
+        //this.state.store.refocusPage();
         break;
       default:
         console.log(event.key);

--- a/src/components/Menu/MenuItem.js
+++ b/src/components/Menu/MenuItem.js
@@ -52,7 +52,7 @@ class MenuItem extends Component {
 
   handleMouseOver (event) {
     event.preventDefault();
-    if (!this.props.store.menuItems[this.props.id].disabled) {
+    if (this.props.store.menuItems[this.props.id] && !this.props.store.menuItems[this.props.id].disabled) {
       this.props.store.setHovering(this.props.id);
     }
     //if ()

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -185,6 +185,7 @@ class Select extends Component {
           ref={(el) => {this.displayElement = el} }
           onClick={this.openSelect.bind(this)}>
             Selected: {(this.state.store.selected) ? this.state.store.menuItems[this.state.store.selected].label : null}
+            hovering: {`${this.state.store.hovering}`}
         </DisplayElement>
          {(this.state.positioning.menuOpen) ? (
           <Menu

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -194,6 +194,7 @@ class Select extends Component {
             menuItems={this.props.menuItems}
             store={this.state.store}
             menuMeta={this.props.menuMeta}
+            {...this.props}
           />
          ) : null}
 

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -166,9 +166,23 @@ class Select extends Component {
   openSelect(ev) {
     if (ev) {
       ev.preventDefault();
+      ev.stopPropagation();
     }
-    this.state.positioning.openMenu();
-    console.log(this.state.positioning.cursorPosition.x, this.state.positioning.cursorPosition.y)
+    if (this.state.positioning.menuOpen && !this.state.store.editing.label) {
+      this.state.positioning.closeMenu();
+    } else {
+      this.state.positioning.openMenu();
+      let closer = () => {
+        if (!this.state.store.editing.label) { 
+          this.state.positioning.closeMenu();
+          document.removeEventListener('click', closer);
+        }
+      };
+      document.addEventListener('click', closer);
+    }
+    
+    
+    //console.log(this.state.positioning.cursorPosition.x, this.state.positioning.cursorPosition.y)
   }
   closeSelect() {
     this.state.positioning.closeMenu();
@@ -181,11 +195,11 @@ class Select extends Component {
         height={this.props.height}
       >
         <DisplayElement
+
           height={this.props.height}
           ref={(el) => {this.displayElement = el} }
           onClick={this.openSelect.bind(this)}>
             Selected: {(this.state.store.selected) ? this.state.store.menuItems[this.state.store.selected].label : null}
-            hovering: {`${this.state.store.hovering}`}
         </DisplayElement>
          {(this.state.positioning.menuOpen) ? (
           <Menu

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -123,7 +123,22 @@ class Select extends Component {
       positioning: createSelectPositioningStore(props),
     };
 
+    //hack to make  sure it closes when you click off the element
+    this.handlers = {}
+    this.handlers.closer = this.externalClose.bind(this);
+
   }
+  externalClose(ev) {
+    this.closeSelect();
+    document.removeEventListener('click', this.handlers.closer);
+  }
+  bindEscape() {
+    document.addEventListener('click', this.handlers.closer);
+  }
+  unbindEscape() {
+    document.removeEventListener('click', this.handlers.closer);
+  }
+
   updatePosition() {
     let element = ReactDOM.findDOMNode(this.displayElement);
     let topPos = element.getBoundingClientRect().top + window.scrollY;
@@ -172,13 +187,6 @@ class Select extends Component {
       this.state.positioning.closeMenu();
     } else {
       this.state.positioning.openMenu();
-      let closer = () => {
-        if (!this.state.store.editing.label) { 
-          this.state.positioning.closeMenu();
-          document.removeEventListener('click', closer);
-        }
-      };
-      document.addEventListener('click', closer);
     }
     
     
@@ -190,6 +198,8 @@ class Select extends Component {
   render() {
     return (
       <Wrapper
+        onMouseEnter={this.unbindEscape.bind(this)}
+        onMouseLeave={this.bindEscape.bind(this)}
         onMouseMove={this.onMouseMove.bind(this)}
         width={this.props.width}
         height={this.props.height}

--- a/src/store/menu.js
+++ b/src/store/menu.js
@@ -50,48 +50,29 @@ const createStore = ({ menuMeta, menuItems }) => {
     },
     setItems(items) {
       this.menuItems = annotateItems(items);
-      this.drawPages();
-      this.refocusPage();
     },
+    
     switchPage(page) {
       //sitches the page
       this.activePage = page;
       this.drawPages();
     },
     nextPage() {
-      //this.switchPage(this.activePage + 1);
     },
     prevPage() {
-      //this.switchPage(this.activePage - 1);
-      
+
     },
     drawPages() {
-      /*
-      let maxItems = this.maxItems();
-      this.pages = chunk(this.menuItems, maxItems);
-      this.paginateSlot = this.pages[this.activePage];
-      if (!this.paginateSlot) { debugger }
-      */
+
     },
     createPages() {
       this.activePage = 0;
-      //this.drawPages();
     },
     //sets the active page to wherever the hovering is located
     refocusPage() {
-      //find the page containing the hovering
-      //let selectedPage = null;
-      /*
-      debugger
-      this.pages.forEach((page, index) => {
-        if (includes(page.map((item) => item.id), this.hovering)) {
-          //this.paginateSlot = page;
-          this.switchPage(index);
-        }
-      });
-      */
-    },
 
+    },
+    
     selectItem(id) {
       if (!this.menuItems[id].disabled) {
         this.selected = id;
@@ -203,7 +184,6 @@ const createStore = ({ menuMeta, menuItems }) => {
 
   });
 
-  extendedStore.drawPages();
   return extendedStore;
 };
 

--- a/src/store/menu.js
+++ b/src/store/menu.js
@@ -1,5 +1,6 @@
-import { observable, autorun} from 'mobx';
+import { observable, autorun, extendObservable} from 'mobx';
 import { chunk, extend, includes, each } from 'lodash';
+
 
 /*
  TODO: width determined by elements, but has max width
@@ -12,11 +13,8 @@ const ITEM_HEIGHT = 24;
 
 const createStore = ({ menuMeta, menuItems }) => {
   let annotateItems = (items) => {
-    if (items) {
-      return items.map((item, index) => extend({}, item, { id: index}));
-    } else {
-      return [];
-    }
+    items.forEach((item, index) => item.id = index);
+    return items;
   };
 
   let store = observable({
@@ -35,11 +33,12 @@ const createStore = ({ menuMeta, menuItems }) => {
     currMenuItem: -1,
     menuMeta,
     menuItems: annotateItems(menuItems),
+    coreItems: menuItems,
     menuHeight: 240,
     paginate: true, //switch on if needed
-    paginateSlot: [], //the items that will be shown on the page
-    pages: [], // the actual pages
-    activePage: 0, //the activly page
+    //paginateSlot: [], //the items that will be shown on the page
+    //pages: [], // the actual pages
+    //activePage: 0, //the activly page
     setChecked(id) {
       this.checked.set(id, true)
     },
@@ -60,42 +59,39 @@ const createStore = ({ menuMeta, menuItems }) => {
       this.drawPages();
     },
     nextPage() {
-      this.switchPage(this.activePage + 1);
+      //this.switchPage(this.activePage + 1);
     },
     prevPage() {
-      this.switchPage(this.activePage - 1);
+      //this.switchPage(this.activePage - 1);
+      
     },
     drawPages() {
+      /*
       let maxItems = this.maxItems();
       this.pages = chunk(this.menuItems, maxItems);
       this.paginateSlot = this.pages[this.activePage];
       if (!this.paginateSlot) { debugger }
+      */
     },
     createPages() {
       this.activePage = 0;
-      this.drawPages();
+      //this.drawPages();
     },
     //sets the active page to wherever the hovering is located
     refocusPage() {
       //find the page containing the hovering
       //let selectedPage = null;
+      /*
+      debugger
       this.pages.forEach((page, index) => {
         if (includes(page.map((item) => item.id), this.hovering)) {
           //this.paginateSlot = page;
           this.switchPage(index);
         }
       });
-    },
-    maxItems() {
-      /* todo: do this later once we have the items part working
-      if ((this.state.store.menuItems.length * ITEM_HEIGHT) > this.menuHeight) {
-        return (menuMeta.height - (2 * ITEM_HEIGHT))/ITEM_HEIGHT;
-      } else {
-        return this.state.store.menuItems.length;
-      }
       */
-      return 9;
     },
+
     selectItem(id) {
       if (!this.menuItems[id].disabled) {
         this.selected = id;
@@ -110,16 +106,19 @@ const createStore = ({ menuMeta, menuItems }) => {
       menuItems.push(this.staging);
       this.menuItems = annotateItems(menuItems); //reannotate the indeces
       this.clearStaging();
-      this.drawPages();
+
+    },
+    addItem(item) {
+      let menuItems = this.menuItems
+      item.id = menuItems.length;
+      menuItems.push(item);
+      this.menuItems = annotateItems(menuItems); //reannotate the indeces
     },
     updateStaging(label) {
       if (this.staging)
         this.staging.label = label;
       else 
         this.staging = { label: label };
-    },
-    addItem({icon, label, disabled}) {
-      //TODO
     },
     isHovering(id) {
       return this.hovering === id;
@@ -170,8 +169,42 @@ const createStore = ({ menuMeta, menuItems }) => {
     }
   });
 
-  store.createPages();
-  return store;
+  //store.createPages();
+  let extendedStore = extendObservable(store, {
+    get foo() {
+      return 'rii'
+    },
+    get pages() {
+      return chunk(this.menuItems, this.maxItems);
+    },
+    get maxItems() {
+      /* todo: do this later once we have the items part working
+      if ((this.state.store.menuItems.length * ITEM_HEIGHT) > this.menuHeight) {
+        return (menuMeta.height - (2 * ITEM_HEIGHT))/ITEM_HEIGHT;
+      } else {
+        return this.state.store.menuItems.length;
+      }
+      */
+      return 9;
+    },
+    get activePage() {
+      let active = 0;
+      this.pages.forEach((page, index) => {
+        if (includes(page.map((item) => item.id), this.hovering)) {
+          //this.paginateSlot = page;
+          active = index;
+        }
+      });
+      return active;
+    },
+    get paginateSlot() {
+      return this.pages[this.activePage];
+    },
+
+  });
+
+  extendedStore.drawPages();
+  return extendedStore;
 };
 
 export default createStore;


### PR DESCRIPTION
This fixes 2 major bugs

1. when add an item into menuItems after initialization, it does not show in menu
There is now a callaback you can pass to the props that will pass the store of the instance to the mounting controller. you can affect the internal store used by menu. See App.js for an example


2. when use `<Select>`, it won't close when I click outside of `<select>`

fixed, Also selecting an item in a menulauncher or select input now closes the item window.


Other chnages:

paging now relies on a computed store, this should simplify a line by line scroll later on
